### PR TITLE
chore: Fix README(stack-directory changed)

### DIFF
--- a/aws-stack/README.md
+++ b/aws-stack/README.md
@@ -11,14 +11,15 @@ see the following links for more information on `stackql`, `stackql-deploy` and 
 
 ## Overview
 
-__`stackql-deploy`__ is a stateless, declarative, SQL driven Infrastructure-as-Code (IaC) framework.  There is no state file required as the current state is assessed for each resource at runtime.  __`stackql-deploy`__ is capable of provisioning, deprovisioning and testing a stack which can include resources across different providers, like a stack spanning `aws` and `azure` for example.  
+**`stackql-deploy`** is a stateless, declarative, SQL driven Infrastructure-as-Code (IaC) framework. There is no state file required as the current state is assessed for each resource at runtime. **`stackql-deploy`** is capable of provisioning, deprovisioning and testing a stack which can include resources across different providers, like a stack spanning `aws` and `azure` for example.
 
 ## Prerequisites
 
-This example requires `stackql-deploy` to be installed using __`pip install stackql-deploy`__.  The host used to run `stackql-deploy` needs the necessary environment variables set to authenticate to your specific provider, in the case of the `aws` provider, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN` must be set, for more information on authentication to `aws` see the [`aws` provider documentation](https://aws.stackql.io/providers/aws).
+This example requires `stackql-deploy` to be installed using **`pip install stackql-deploy`**. The host used to run `stackql-deploy` needs the necessary environment variables set to authenticate to your specific provider, in the case of the `aws` provider, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN` must be set, for more information on authentication to `aws` see the [`aws` provider documentation](https://aws.stackql.io/providers/aws).
 
-> __Note for macOS users__  
-> to install `stackql-deploy` in a virtual environment (which may be necessary on __macOS__), use the following:
+> **Note for macOS users**  
+> to install `stackql-deploy` in a virtual environment (which may be necessary on **macOS**), use the following:
+>
 > ```bash
 > python3 -m venv myenv
 > source myenv/bin/activate
@@ -27,13 +28,13 @@ This example requires `stackql-deploy` to be installed using __`pip install stac
 
 ## Usage
 
-Adjust the values in the [__`stackql_manifest.yml`__](stackql_manifest.yml) file if desired.  The [__`stackql_manifest.yml`__](stackql_manifest.yml) file contains resource configuration variables to support multiple deployment environments, these will be used for `stackql` queries in the `resources` and `resources` folders.  
+Adjust the values in the [**`stackql_manifest.yml`**](stackql_manifest.yml) file if desired. The [**`stackql_manifest.yml`**](stackql_manifest.yml) file contains resource configuration variables to support multiple deployment environments, these will be used for `stackql` queries in the `resources` and `resources` folders.
 
 The syntax for the `stackql-deploy` command is as follows:
 
 ```bash
 stackql-deploy { build | test | teardown } { stack-directory } { deployment environment} [ optional flags ]
-``` 
+```
 
 ### Deploying a stack
 
@@ -41,7 +42,7 @@ For example, to deploy the stack to an environment labeled `sit`, run the follow
 
 ```bash
 stackql-deploy build \
-examples/aws/aws-stack sit \
+aws-stack/ sit \
 -e AWS_REGION=ap-southeast-2
 ```
 
@@ -49,7 +50,7 @@ Use the `--dry-run` flag to view the queries to be run without actually running 
 
 ```bash
 stackql-deploy build \
-examples/aws/aws-stack sit \
+aws-stack/ sit \
 -e AWS_REGION=ap-southeast-2 \
 --dry-run
 ```
@@ -60,7 +61,7 @@ To test a stack to ensure that all resources are present and in the desired stat
 
 ```bash
 stackql-deploy test \
-examples/aws/aws-stack sit \
+aws-stack/ sit \
 -e AWS_REGION=ap-southeast-2
 ```
 
@@ -70,6 +71,6 @@ To destroy or deprovision all resources in a stack for our `sit` deployment exam
 
 ```bash
 stackql-deploy teardown \
-examples/aws/aws-stack sit \
+aws-stack/ sit \
 -e AWS_REGION=ap-southeast-2
 ```


### PR DESCRIPTION
Fix stack-directory's name in README.
- there is only `aws-stack` dir for the stack-directory.