### PR TITLE
Add a usecase for creating s3 and gcs(multi-cloud stack)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ stackql-zip
 stackql-aws-cloud-shell.sh
 stackql-azure-cloud-shell.sh
 stackql-google-cloud-shell.sh
+.envrc
+
+.DS_Store

--- a/multi-cloud-stack/create-s3-gcs-bucket/README.md
+++ b/multi-cloud-stack/create-s3-gcs-bucket/README.md
@@ -1,0 +1,75 @@
+# `stackql-deploy` starter project for `aws`
+
+> for starter projects using other providers, try `stackql-deploy my_stack --provider=azure` or `stackql-deploy my_stack --provider=google`
+
+see the following links for more information on `stackql`, `stackql-deploy` and the `aws` provider:
+
+- [`aws` provider docs](https://stackql.io/registry/aws)
+- [`stackql`](https://github.com/stackql/stackql)
+- [`stackql-deploy` PyPI home page](https://pypi.org/project/stackql-deploy/)
+- [`stackql-deploy` GitHub repo](https://github.com/stackql/stackql-deploy)
+
+## Overview
+
+__`stackql-deploy`__ is a stateless, declarative, SQL driven Infrastructure-as-Code (IaC) framework.  There is no state file required as the current state is assessed for each resource at runtime.  __`stackql-deploy`__ is capable of provisioning, deprovisioning and testing a stack which can include resources across different providers, like a stack spanning `aws` and `azure` for example.  
+
+## Prerequisites
+
+This example requires `stackql-deploy` to be installed using __`pip install stackql-deploy`__.  The host used to run `stackql-deploy` needs the necessary environment variables set to authenticate to your specific provider, in the case of the `aws` provider, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and optionally `AWS_SESSION_TOKEN` must be set, for more information on authentication to `aws` see the [`aws` provider documentation](https://aws.stackql.io/providers/aws).
+
+> __Note for macOS users__  
+> to install `stackql-deploy` in a virtual environment (which may be necessary on __macOS__), use the following:
+> ```bash
+> python3 -m venv myenv
+> source myenv/bin/activate
+> pip install stackql-deploy
+> ```
+
+## Usage
+
+Adjust the values in the [__`stackql_manifest.yml`__](stackql_manifest.yml) file if desired.  The [__`stackql_manifest.yml`__](stackql_manifest.yml) file contains resource configuration variables to support multiple deployment environments, these will be used for `stackql` queries in the `resources` and `resources` folders.  
+
+The syntax for the `stackql-deploy` command is as follows:
+
+```bash
+stackql-deploy { build | test | teardown } { stack-directory } { deployment environment} [ optional flags ]
+``` 
+
+### Deploying a stack
+
+For example, to deploy the stack to an environment labeled `sit`, run the following:
+
+```bash
+stackql-deploy build \
+examples/aws/aws-stack sit \
+-e AWS_REGION=ap-southeast-2
+```
+
+Use the `--dry-run` flag to view the queries to be run without actually running them, for example:
+
+```bash
+stackql-deploy build \
+examples/aws/aws-stack sit \
+-e AWS_REGION=ap-southeast-2 \
+--dry-run
+```
+
+### Testing a stack
+
+To test a stack to ensure that all resources are present and in the desired state, run the following (in our `sit` deployment example):
+
+```bash
+stackql-deploy test \
+examples/aws/aws-stack sit \
+-e AWS_REGION=ap-southeast-2
+```
+
+### Tearing down a stack
+
+To destroy or deprovision all resources in a stack for our `sit` deployment example, run the following:
+
+```bash
+stackql-deploy teardown \
+examples/aws/aws-stack sit \
+-e AWS_REGION=ap-southeast-2
+```

--- a/multi-cloud-stack/create-s3-gcs-bucket/resources/example_gcs_bucket.iql
+++ b/multi-cloud-stack/create-s3-gcs-bucket/resources/example_gcs_bucket.iql
@@ -1,0 +1,43 @@
+/*+ exists */
+SELECT COUNT(*) as count FROM google.storage.buckets
+WHERE name = '{{ gcp_bucket_name }}'
+AND project = '{{ gcp_project_id }}'
+
+/*+ create */
+INSERT INTO google.storage.buckets
+(
+ data__name,
+ data__location,
+ data__labels,
+ project
+)
+SELECT 
+'{{ gcp_bucket_name }}',
+'{{ gcp_region }}',
+'{{ bucket_labels }}',
+'{{ gcp_project_id }}';
+
+
+/*+ statecheck, retries=3, retry_delay=1 */
+SELECT COUNT(*) as count
+FROM google.storage.buckets
+WHERE name = '{{ gcp_bucket_name }}'
+AND project = '{{ gcp_project_id }}'
+AND LOWER(location) = LOWER('{{ gcp_region }}');
+
+
+/*+ exports, retries=3, retry_delay=1 */
+SELECT 
+projectNumber as "gcp_project_number",
+name as "gcs_bucket_name", 
+id as "gcs_id",
+labels as "gcs_labels"
+FROM google.storage.buckets
+WHERE LOWER(location) = LOWER('{{ gcp_region }}')
+AND name = '{{ gcp_bucket_name }}'
+AND project = '{{ gcp_project_id }}';
+
+
+/*+ delete */
+DELETE FROM google.storage.buckets
+WHERE bucket = '{{ gcp_bucket_name }}';

--- a/multi-cloud-stack/create-s3-gcs-bucket/resources/example_s3_bucket.iql
+++ b/multi-cloud-stack/create-s3-gcs-bucket/resources/example_s3_bucket.iql
@@ -1,0 +1,44 @@
+/*+ exists */
+SELECT COUNT(*) as count FROM
+(
+SELECT bucket_name
+FROM aws.s3.buckets
+WHERE region = '{{ aws_region }}'
+AND bucket_name = '{{ aws_bucket_name }}'
+) t;
+
+/*+ create */
+INSERT INTO aws.s3.buckets (
+ BucketName,
+ Tags,
+ region
+)
+SELECT 
+'{{ aws_bucket_name }}',
+'{{ bucket_tags }}',
+'{{ aws_region }}';
+
+/*+ statecheck, retries=3, retry_delay=1 */
+SELECT COUNT(*) as count FROM
+(
+SELECT bucket_name,
+arn
+FROM aws.s3.buckets
+WHERE region = '{{ aws_region }}'
+AND bucket_name = '{{ aws_bucket_name }}'
+) t;
+WHERE arn = 'arn:aws:s3:::{{ aws_bucket_name }}';
+
+/*+ exports, retries=3, retry_delay=1 */
+SELECT aws_bucket_name, arn, aws_tags FROM
+(
+SELECT bucket_name as "aws_bucket_name", arn, tags as "aws_tags"
+FROM aws.s3.buckets
+WHERE region = '{{ aws_region }}'
+AND bucket_name = '{{ aws_bucket_name }}'
+) t;
+
+/*+ delete */
+DELETE FROM aws.s3.buckets
+WHERE data__Identifier = '{{ aws_bucket_name }}'
+AND region = '{{ aws_region }}'

--- a/multi-cloud-stack/create-s3-gcs-bucket/stackql_manifest.yml
+++ b/multi-cloud-stack/create-s3-gcs-bucket/stackql_manifest.yml
@@ -1,0 +1,66 @@
+#
+# aws starter project manifest file, add and update values as needed
+#
+version: 1
+name: "s3-gcs-bucket"
+description: description for "s3-gcs-bucket"
+providers:
+  - aws
+  - google
+globals:
+  # aws global values
+  - name: aws_region
+    description: aws region
+    value: "{{ AWS_REGION }}"
+  - name: global_tags
+    value:
+      - Key: Provisioner
+        Value: stackql
+      - Key: StackName
+        Value: "{{ stack_name }}"
+      - Key: StackEnv
+        Value: "{{ stack_env }}"
+      - Key: Provider
+        Value: aws
+  # google global values
+  - name: gcp_region
+    description: gcp region
+    value: "{{ GCP_REGION }}"
+  - name: gcp_project_id
+    description: google project name
+    value: "{{ MY_PROJECT_NAME }}"
+  - name: global_labels
+    value:
+      provisioner: stackql
+      stack_name: "{{ stack_name }}"
+      stack_env: "{{ stack_env }}"
+      provider: gcp
+resources:
+  - name: example_s3_bucket
+    props:
+      - name: aws_bucket_name
+        value: "{{ stack_env }}-{{ stack_name }}"
+      - name: bucket_tags
+        value:
+          - Key: Name
+            Value: "{{ stack_env }}-{{ stack_name }}"
+        merge: 
+          - global_tags
+    exports:
+      - aws_bucket_name
+      - arn
+      - aws_tags
+  - name: example_gcs_bucket
+    props:
+      - name: gcp_bucket_name
+        value: "{{ stack_env }}-{{ stack_name }}"
+      - name: bucket_labels
+        value:
+          name: "{{ stack_env }}-{{ stack_name }}"
+        merge: 
+          - global_labels
+    exports:
+      - gcp_project_number
+      - gcs_bucket_name
+      - gcs_id
+      - gcs_labels


### PR DESCRIPTION
## Description
- Made a usecase for creating s3 and gcs bucket (multi-cloud stack)
- With `stackql`, we don't have to make a separate manifest file such as `provider block` or `backend setting` like terraform 😎 
![image](https://github.com/user-attachments/assets/b0f1bcb8-0335-4b80-b1b7-3892c3eb7000)


## Additional Notes

- I can show you the demo if @jeffreyaven or others want anytime. :) 
- If you need any questions and other suggestions let me know.